### PR TITLE
Updated OSX Build instructions in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Contibuted by Björn Kalkbrenner: https://github.com/terminar
 
 If you haven't done this before, get the "Command Line Tools for Xcode" and git (via https://brew.sh/ - Homebrew?).
 
-- git clone https://github.com/brummbrum/reaKontrol.git
+- git clone https://github.com/brummbrum/reaKontrol.git --recursive
 - cd reaKontrol
 - make -f Makefile.osx install
 


### PR DESCRIPTION
Added --recursive flag to git clone in readme OSX Build instructions to account for submodule