### PR TITLE
changed wdl master branch to main

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ elseif(APPLE)
     include(FetchContent)
     FetchContent_Declare(WDL
         GIT_REPOSITORY  https://github.com/justinfrankel/WDL.git
+        GIT_TAG main
         SOURCE_DIR "${CMAKE_SOURCE_DIR}/WDL"
     )
     FetchContent_MakeAvailable(WDL)


### PR DESCRIPTION
Cmake throws an error because wdl master branch is renamed to main.